### PR TITLE
Custom 404 with redirect

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,10 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="refresh" content="0;url=http://www.civichack.me/2014">
+	<meta http-equiv="refresh" content="5;url=http://www.civichack.me/2014">
 	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 	<link rel="shortcut icon" href="http://www.hackmaine.org/favicon.ico">
 	<title>Redirecting...</title>
+	<script type="text/javascript">
+		var redirectURL = 'http://www.civichack.me/2014/#';
+		var fourOhFour = window.location.pathname.split('/');
+		window.location.href = redirectURL + fourOhFour[1]; // Adds 404'd url to end of anchor link; should jump to anchor if it exists or top of page if it doesn't.
+	</script>
 </head>
 <body>
 	<p>Please wait while we load the main page.</p>


### PR DESCRIPTION
I think I have a solution for your 404 problem... This _should_ take the URL they were trying to reach and append it to an anchor link & redirect to the correct URL. Defaults to the meta refresh in case the script fails.

`http://mainecivichackday.com/about/` => `http://www.civichack.me/2014/#about`

Couldn't fully test it because you need a custom URL to use custom 404 pages on github. But it should work (in theory)

Fixes #27
